### PR TITLE
Declare dependencies in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
         }
     ],
     "homepage": "https://github.com/mateussantin/magento2-admin-order-status-color",
-    "require": {},
+    "require": {
+        "magento/framework": "^100.0.2 || ^101.0 || ^102.0 || ^103.0",
+        "magento/module-sales": "^100.0.2 || ^101.0 || ^102.0 || ^103.0",
+        "magento/module-ui": "^100.0.2 || ^101.0"
+    },
     "autoload": {
         "psr-4": {
             "Mateus\\OrderStatusColor\\": ""

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     ],
     "homepage": "https://github.com/mateussantin/magento2-admin-order-status-color",
     "require": {},
-    "minimum-stability": "dev",
     "autoload": {
         "psr-4": {
             "Mateus\\OrderStatusColor\\": ""

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Changes the color of the order status column in the UI grid, based on the current status of the order.",
     "license": "proprietary",
     "type": "magento2-module",
-    "version": "1.0.1",
     "keywords": [
         "mateussantin",
         "magento2",

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,31 @@
 {
     "name": "mateus/module-orderstatuscolor",
     "description": "Changes the color of the order status column in the UI grid, based on the current status of the order.",
-    "keywords": ["mateussantin", "magento2", "Order", "Order Status", "Order Status Color"],
-    "homepage": "https://github.com/mateussantin/magento2-admin-order-status-color",
+    "license": "proprietary",
     "type": "magento2-module",
     "version": "1.0.1",
-    "license": "proprietary",
+    "keywords": [
+        "mateussantin",
+        "magento2",
+        "Order",
+        "Order Status",
+        "Order Status Color"
+    ],
     "authors": [
         {
             "name": "Mateus Santin",
             "email": "mateussantin.jr@gmail.com"
         }
     ],
-    "minimum-stability": "dev",
+    "homepage": "https://github.com/mateussantin/magento2-admin-order-status-color",
     "require": {},
+    "minimum-stability": "dev",
     "autoload": {
-        "files": [
-            "registration.php"
-        ],
         "psr-4": {
             "Mateus\\OrderStatusColor\\": ""
-        }
+        },
+        "files": [
+            "registration.php"
+        ]
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,5 +6,9 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Mateus_OrderStatusColor" setup_version="1.0.0">
+        <sequence>
+            <module name="Magento_Sales"/>
+            <module name="Magento_Ui"/>
+        </sequence>
     </module>
 </config>


### PR DESCRIPTION
This pull request replaces the empty list of requirements/dependencies with a list of actual dependencies for this module.

I have also removed the version number to facilitate easier version management going forward - see https://github.com/mateussantin/magento2-admin-order-status-color/issues/2